### PR TITLE
Removing browser animation module to enable lazy loading

### DIFF
--- a/src/remote-desktop.module.ts
+++ b/src/remote-desktop.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import {
     ConnectingMessageComponent,
@@ -16,8 +15,7 @@ import {
 
 @NgModule({
     imports: [
-        CommonModule,
-        BrowserAnimationsModule
+        CommonModule
     ],
     declarations: [
         RemoteDesktopComponent,


### PR DESCRIPTION
When using the component on lazy loading, it will get "BrowserModule has already been loaded" error,  we solve this by removing the import of BrowserAnimationsModule which exports the BrowserModule